### PR TITLE
OHLC endpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,13 @@ pub use kraken_rest_client::*;
 mod messages;
 use messages::{
     unpack_kraken_result, AddOrderRequest, AssetPairsRequest, CancelAllOrdersAfterRequest, CancelOrderRequest, Empty,
-    GetOpenOrdersRequest, KrakenResult, TickerRequest,
+    GetOpenOrdersRequest, KrakenResult, OHLCRequest, TickerRequest,
 };
 pub use messages::{
-    AddOrderResponse, AssetPairsResponse, AssetTickerInfo, AssetsResponse, BalanceResponse, BsType,
+    AddOrderResponse, AssetOHLCInfo, AssetPairsResponse, AssetTickerInfo, AssetsResponse, BalanceResponse, BsType,
     CancelAllOrdersAfterResponse, CancelAllOrdersResponse, CancelOrderResponse, GetOpenOrdersResponse,
-    GetWebSocketsTokenResponse, OrderAdded, OrderFlag, OrderInfo, OrderStatus, OrderType, SystemStatusResponse,
-    TickerResponse, TimeResponse, TxId, UserRefId,
+    GetWebSocketsTokenResponse, OHLCResponse, OrderAdded, OrderFlag, OrderInfo, OrderStatus, OrderType,
+    SystemStatusResponse, TickerResponse, TimeResponse, TxId, UserRefId,
 };
 
 use core::convert::TryFrom;
@@ -24,6 +24,8 @@ use std::collections::BTreeSet;
 // Websockets API support
 #[cfg(feature = "ws")]
 pub mod ws;
+
+mod tests;
 
 /// A description of a market order to place
 #[derive(Debug, Clone)]
@@ -97,6 +99,17 @@ impl KrakenRestAPI {
         let result: Result<KrakenResult<TickerResponse>> = self
             .client
             .query_public("Ticker", TickerRequest { pair: pairs.join(",") });
+        result.and_then(unpack_kraken_result)
+    }
+
+    /// (Public) Get the ohlc data for one or more asset pairs
+    ///
+    /// Arguments:
+    /// * pairs: A list of Kraken asset pair strings to get ticker info about
+    /// * interval: An integer representing time frame interval in minutes (enum: 1 5 15 30 60 240 1440 10080 21600)
+    /// * since: An integer representing of the epoch (in ms) that you want to get data since
+    pub fn ohlc(&self, pairs: Vec<String>) -> Result<OHLCResponse> {
+        let result: Result<KrakenResult<OHLCResponse>> = self.client.query_public("OHLC", OHLCRequest { pair: pairs.join(","), interval: None, since: None });
         result.and_then(unpack_kraken_result)
     }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -141,6 +141,35 @@ pub struct AssetTickerInfo {
 /// Type alias for response of Ticker API call
 pub type TickerResponse = HashMap<String, AssetTickerInfo>;
 
+/// A query object to kraken public "OHLC" API call
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct OHLCRequest {
+    /// A comma-separated list of kraken asset pair strings
+    pub pair: String,
+    /// An integer representing time frame interval in minutes (enum: 1 5 15 30 60 240 1440 10080 21600)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval: Option<i64>,
+    /// An integer representing of the epoch (in ms) that you want to get data since
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub since: Option<i64>,
+}
+
+/// Result of kraken public "OHLC" API call
+// It's result object includes arrays containing differing types, and is somewhat complex.
+// See: <https://docs.kraken.com/rest/#operation/getOHLCData>
+// Array of tick data arrays [int <time>, string <open>, string <high>, string <low>, string <close>, string <vwap>, string <volume>, int <count>]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetOHLCInfo {
+    /// last is an ID to be used as since when polling for new, committed OHLC data
+    pub last: i64,
+    /// Array of tick data arrays [int <time>, string <open>, string <high>, string <low>, string <close>, string <vwap>, string <volume>, int <count>]
+    #[serde(alias = "*", alias="XXBTZUSD", default)]
+    pub pair: Vec<(i64, String, String, String, String, String, String, i64)>,
+}
+
+/// Type alias for response of OHLC API call
+pub type OHLCResponse = AssetOHLCInfo;
+
 /// Type alias for response of Balance API call
 pub type BalanceResponse = HashMap<String, Decimal>;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// test_ohlc_serialization sets up dummy data and then reads it in, serializing it to the OHLCResponse.
+    ///   A working demonstration of this technique can be found below
+    #[test]
+    fn test_ohlc_serialization() {
+        let ohlc_test_data_from_result = r#"
+        {
+          "LOLCOIN": [
+            [
+                1616662740,
+                "52591.9",
+                "52599.9",
+                "52591.8",
+                "52599.9",
+                "52599.1",
+                "0.11091626",
+                5
+                ]
+            ],
+            "last": 1616662740
+        }
+        "#;
+
+        let ohlc_info: AssetOHLCInfo = serde_json::from_str(ohlc_test_data_from_result).unwrap();
+        assert_eq!(ohlc_info.last, 1616662740);
+    }
+
+    /// It seems that when the result for AssetTickerInfo is unwrapped and serialized,
+    ///   it's scope is smaller than the previous example.
+    #[test]
+    fn test_asset_ticker_serialization() {
+        let ati_test_data = r#"
+        {
+            "a": [
+                "52609.60000",
+                "1",
+                "1.000"
+            ],
+            "b": [
+                "52609.50000",
+                "1",
+                "1.000"
+            ],
+            "c": [
+                "52641.10000",
+                "0.00080000"
+            ],
+            "v": [
+                "1920.83610601",
+                "7954.00219674"
+            ],
+            "p": [
+                "52389.94668",
+                "54022.90683"
+            ],
+            "t": [
+                23329,
+                80463
+            ],
+            "l": [
+                "51513.90000",
+                "51513.90000"
+            ],
+            "h": [
+                "53219.90000",
+                "57200.00000"
+            ],
+            "o": "52280.40000"
+        }
+        "#;
+
+        let ati: AssetTickerInfo = serde_json::from_str(ati_test_data).unwrap();
+        assert_eq!(ati.a[0], "52609.60000");
+    }
+
+    #[test]
+    fn test_client_connection() {
+      let conf = KrakenRestConfig::default();
+      let client = KrakenRestAPI::try_from(conf).unwrap();
+
+      let ohlc_res = client.ohlc(vec!["XXBTZUSD".to_string()]).unwrap();
+      for candle in ohlc_res.pair {
+          println!("Candle: {:?}", candle);
+      }
+
+      // let xxbtzusd = _ohlc_res.get("XXBTZUSD").unwrap();
+      // assert!(xxbtzusd.pair.0 == 0);
+    }
+}


### PR DESCRIPTION
Hi and thanks for developing this project.

I'm a bit hung up on how to implement this endpoint correctly, and I was hoping you might be able to point me in the right direction. I'm fairly new to rust, but I think I _could_ implement a custom `Serializer` and `Deserializer`, but I'm hoping that's not necessary. 

I borrowed a tuple from [json to rust](https://transform.tools/json-to-rust-serde) using the [example data from the kraken api](https://docs.kraken.com/rest/#operation/getOHLCData):

```
use serde_derive::Deserialize;
use serde_derive::Serialize;
use serde_json::Value;

#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
#[serde(rename_all = "camelCase")]
pub struct Root {
    pub error: Vec<Value>,
    pub result: Result,
}

#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
#[serde(rename_all = "camelCase")]
pub struct Result {
    #[serde(rename = "XXBTZUSD")]
    pub xxbtzusd: Vec<(i64, String, String, String, String, String, String, i64)>,
    pub last: i64,
}
```

This looks similar to the handling in `KrakenResponse`, though it looks like most of these type aliases use `HashMap`s, I'm assuming because its capturing the pairs that way. This model parses, but only if I use default, it's not actually functional:

```
#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct AssetOHLCInfo {
    /// last is an ID to be used as since when polling for new, committed OHLC data
    pub last: i64,
    /// Array of tick data arrays [int <time>, string <open>, string <high>, string <low>, string <close>, string <vwap>, string <volume>, int <count>]
    #[serde(alias = "*", alias="XXBTZUSD", default)]
    pub pair: Vec<(i64, String, String, String, String, String, String, i64)>,
}
```

I've written a few tests to model the trouble, however to reproduce, you would need to remove the field annotations from `AssetOHLCInfo::pair`.


Thanks for any help you can provide.