### PR TITLE
Implement support for heartbeat, ping, pong in a WS connection

### DIFF
--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -11,10 +11,12 @@ use std::sync::{atomic::Ordering, Arc};
 use std::{
     collections::{BTreeMap, HashMap},
     thread,
+    time::{Duration, Instant},
 };
 use tokio::{
     runtime,
     sync::{mpsc, oneshot},
+    time,
 };
 
 mod conn;
@@ -56,6 +58,8 @@ impl KrakenWsAPI {
         let worker_thread = Some(thread::Builder::new().name("kraken-ws-internal-runtime".into()).spawn(
             move || {
                 rt.block_on(async move {
+                    // Every second, confirm that we got a heart beat, or send a ping / expect a pong
+                    let mut interval = time::interval(Duration::from_secs(1));
                     loop {
                         tokio::select! {
                             stream_result = stream.next() => {
@@ -110,6 +114,30 @@ impl KrakenWsAPI {
                                         }
                                     }
                                 }
+                            }
+                            _ = interval.tick() => {
+                                 if let Some(time) = client.get_last_message_time() {
+                                    // If we haven't heard anything in a while that's bad
+                                    // Kraken says they send a heartbeat about every second
+                                    let now = Instant::now();
+                                    if time + Duration::from_secs(2) < now {
+                                        // Check if we earlier sent a ping
+                                        if let Some(ping_time) = client.get_last_outstanding_ping_time() {
+                                            if ping_time + Duration::from_secs(1) < now {
+                                                log::error!("Kraken did not respond to ping, closing stream");
+                                                drop(client.close().await);
+                                                return;
+                                            }
+                                        } else {
+                                            // There is no outstanding ping, let's send a ping
+                                            if let Err(err) = client.ping().await {
+                                                log::error!("error sending ping, closing stream: {}", err);
+                                                drop(client.close().await);
+                                                return;
+                                            }
+                                        }
+                                    }
+                                 }
                             }
                         }
                     }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -116,7 +116,7 @@ impl KrakenWsAPI {
                                 }
                             }
                             _ = interval.tick() => {
-                                 if let Some(time) = client.get_last_message_time() {
+                                if let Some(time) = client.get_last_message_time() {
                                     // If we haven't heard anything in a while that's bad
                                     // Kraken says they send a heartbeat about every second
                                     let now = Instant::now();
@@ -137,7 +137,7 @@ impl KrakenWsAPI {
                                             }
                                         }
                                     }
-                                 }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Kraken specifies that they send a heartbeat about every second,
and that application level pings can be sent to confirm that the
connection is still alive if a heartbeat is missed.

In this commit, we make the WS connection listen to these
heartbeats and check periodically if we have received messages
recently -- if not then we send a ping, and if this isn't answered
in a second then we close the stream.

This should fix issues where connectivity issues lead to undetected
states where the book stops getting updates.