### PR TITLE
handle a race more gracefully when partial updates race ahead of original

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -265,9 +265,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "conf"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4201762fcfd72600b1c852bf6a731a1797ce6b56d1d6f7a32a206a1078ae0438"
+checksum = "f37e148dbc927d8aa1d7f07fc6c06db98d2f102485a14239da7f3d8441ed1f46"
 dependencies = [
  "anstyle",
  "clap",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "conf_derive"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35060dcea66f85eb49bf7834d451089a6d5cde0f75957aa78bcc7029dc050015"
+checksum = "def1cc7b12095ba8d2b9b04e27d7524d4b117795a9f1f232d962ea53f1c6b81b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -405,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1427,7 +1427,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1732,7 +1732,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/examples/kraken-feed.rs
+++ b/examples/kraken-feed.rs
@@ -1,3 +1,6 @@
+// TODO: remove when rustc 1.93+ is released (rust-lang/rust#147648 regression in 1.92.0)
+#![allow(unused_assignments)]
+
 use anstyle::{AnsiColor, Style};
 use conf::{Conf, Subcommands};
 use displaydoc::Display;

--- a/examples/kraken.rs
+++ b/examples/kraken.rs
@@ -1,3 +1,6 @@
+// TODO: remove when rustc 1.93+ is released (rust-lang/rust#147648 regression in 1.92.0)
+#![allow(unused_assignments)]
+
 use anstyle::{AnsiColor, Style};
 use conf::{Conf, Subcommands};
 use core::convert::TryFrom;

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -67,6 +67,7 @@ pub mod comma_separated {
 /// #[serde(with = "crate::serde_helpers::display_fromstr")]
 /// pub validate: bool,
 /// ```
+#[allow(dead_code)]
 pub mod display_fromstr {
     use super::*;
 

--- a/src/ws/conn.rs
+++ b/src/ws/conn.rs
@@ -908,12 +908,25 @@ impl KrakenWsClient {
                             }
                         }
                         Entry::Vacant(entry) => {
-                            // Parse the data as an OrderInfo object and add the new order id
-                            let order_info: OrderInfo = serde_json::from_value(val.clone()).map_err(|err| {
-                                log::error!("Could not parse open order data as an OrderInfo object: {}", err);
-                                "OrderInfo deserialization error"
-                            })?;
-                            entry.insert(order_info);
+                            // Try to parse as a full OrderInfo (new order) or as a partial update
+                            // Kraken sends partial updates (vol_exec, cost, fee, avg_price only) for
+                            // orders that may not be in our map yet (e.g. after reconnect).
+                            match serde_json::from_value::<OrderInfo>(val.clone()) {
+                                Ok(order_info) => {
+                                    entry.insert(order_info);
+                                }
+                                Err(err) => {
+                                    // This is likely a partial fill update for an order we don't have.
+                                    // This can happen after reconnection or if the initial snapshot
+                                    // didn't include this order. Log and skip.
+                                    log::warn!(
+                                        "Received update for unknown order {}: {} (payload: {})",
+                                        order_id,
+                                        err,
+                                        val
+                                    );
+                                }
+                            }
                         }
                     }
                 }

--- a/src/ws/messages.rs
+++ b/src/ws/messages.rs
@@ -134,6 +134,24 @@ pub enum OrderStatus {
     Expired,
 }
 
+/// Partial order update sent by Kraken WS API for fill updates.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrderInfoPartialUpdate {
+    /// User reference id for the order
+    pub userref: UserRefId,
+    /// volume executed (base currency unless viqc set in oflags)
+    pub vol_exec: Decimal,
+    /// total cost (quote currency unless unless viqc set in oflags)
+    pub cost: Decimal,
+    /// total fee (quote currency)
+    pub fee: Decimal,
+    /// average price (quote currency unless viqc set in oflags)
+    pub avg_price: Decimal,
+    /// order flags (comma separated list)
+    #[serde(with = "comma_separated")]
+    pub oflags: BTreeSet<OrderFlag>,
+}
+
 /// Order-info used in OpenOrders and QueryOrders APIs
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrderInfo {

--- a/src/ws/messages.rs
+++ b/src/ws/messages.rs
@@ -375,7 +375,7 @@ mod tests {
         "type": "sell",
         "vol": "1000000000.00000000"
       }"#;
-        let val: OwnTrade = serde_json::from_str(&json).unwrap();
+        let val: OwnTrade = serde_json::from_str(json).unwrap();
 
         assert_eq!(val.pair, "XBT/EUR");
         assert_eq!(val.bs_type, BsType::Sell);


### PR DESCRIPTION
i saw this error in my logs a few times, i think that sometimes the partial updates for an order get sent out before the order is announced to websockets, which triggers this error. in this case we log a warning and skip.